### PR TITLE
Implement macOS widget functionality

### DIFF
--- a/src/Zeal/Info.plist
+++ b/src/Zeal/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AppIdentifierPrefix</key>
+	<string>$(AppIdentifierPrefix)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/src/Zeal/Services/KeychainService.swift
+++ b/src/Zeal/Services/KeychainService.swift
@@ -3,17 +3,27 @@ import Security
 
 final class KeychainService {
     static let shared = KeychainService()
-    
+
     private init() {}
-    
+
     enum KeychainError: Error {
         case duplicateEntry
         case unknown(OSStatus)
         case itemNotFound
+        case missingAppIdentifierPrefix
     }
-    
-    // accessGroup should match the one in entitlements (TeamID.Group)
-    private let accessGroup = "BB726GNDGJ.com.zeabur.Zeal.SharedKeychain"
+
+    /// Dynamically get the access group using AppIdentifierPrefix from Info.plist
+    /// This allows the app to work with any Team ID
+    private var accessGroup: String {
+        // Try to get AppIdentifierPrefix from Info.plist
+        if let prefix = Bundle.main.object(forInfoDictionaryKey: "AppIdentifierPrefix") as? String {
+            return "\(prefix)com.zeabur.Zeal.SharedKeychain"
+        }
+        // Fallback for development/testing (will be replaced by actual Team ID in release)
+        print("Warning: AppIdentifierPrefix not found in Info.plist, using fallback")
+        return "BB726GNDGJ.com.zeabur.Zeal.SharedKeychain"
+    }
     
     func save(key: String, value: String) throws {
         let data = value.data(using: .utf8)!

--- a/src/ZealWidget/Info.plist
+++ b/src/ZealWidget/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AppIdentifierPrefix</key>
+	<string>$(AppIdentifierPrefix)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/src/ZealWidget/Provider.swift
+++ b/src/ZealWidget/Provider.swift
@@ -3,29 +3,38 @@ import SwiftUI
 
 struct Provider: AppIntentTimelineProvider {
     func placeholder(in context: Context) -> SimpleEntry {
-        SimpleEntry(date: Date(), projects: [
-            ZeaburProject(_id: "1", name: "My Project", services: []),
-            ZeaburProject(_id: "2", name: "Demo App", services: [])
-        ])
+        SimpleEntry(
+            date: Date(),
+            projects: [
+                ZeaburProject(_id: "1", name: "My Project", services: []),
+                ZeaburProject(_id: "2", name: "Demo App", services: [])
+            ],
+            isAuthenticated: true
+        )
     }
 
     func snapshot(for configuration: SelectProjectIntent, in context: Context) async -> SimpleEntry {
-        let entry = SimpleEntry(date: Date(), projects: [
-            ZeaburProject(_id: "1", name: "My Project", services: [ZeaburServiceItem(_id: "s1", name: "web")]),
-            ZeaburProject(_id: "2", name: "Demo App", services: [])
-        ])
-        return entry
+        SimpleEntry(
+            date: Date(),
+            projects: [
+                ZeaburProject(_id: "1", name: "My Project", services: [ZeaburServiceItem(_id: "s1", name: "web")]),
+                ZeaburProject(_id: "2", name: "Demo App", services: [])
+            ],
+            isAuthenticated: true
+        )
     }
-    
+
     func timeline(for configuration: SelectProjectIntent, in context: Context) async -> Timeline<SimpleEntry> {
         var projects: [ZeaburProject] = []
-        
+        var errorMessage: String?
+        let isAuthenticated = ZeaburService.shared.isAuthenticated
+
         // Attempt to fetch real data
-        if ZeaburService.shared.isAuthenticated {
+        if isAuthenticated {
             do {
                 // Force refresh to get latest status
                 let allProjects = try await ZeaburService.shared.fetchProjects(forceRefresh: true)
-                
+
                 if let selectedProject = configuration.project {
                     // Filter for the selected project
                     projects = allProjects.filter { $0._id == selectedProject.id }
@@ -35,14 +44,20 @@ struct Provider: AppIntentTimelineProvider {
                 }
             } catch {
                 print("Widget fetch error: \(error)")
+                errorMessage = "Failed to load projects"
             }
         } else {
             print("Widget: Not authenticated")
         }
-        
-        let entry = SimpleEntry(date: Date(), projects: projects)
-        
-        // Refresh every 15 minutes or when app data changes
+
+        let entry = SimpleEntry(
+            date: Date(),
+            projects: projects,
+            isAuthenticated: isAuthenticated,
+            errorMessage: errorMessage
+        )
+
+        // Refresh every 15 minutes
         let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date())!
         return Timeline(entries: [entry], policy: .after(nextUpdate))
     }
@@ -51,4 +66,13 @@ struct Provider: AppIntentTimelineProvider {
 struct SimpleEntry: TimelineEntry {
     let date: Date
     let projects: [ZeaburProject]
+    let isAuthenticated: Bool
+    let errorMessage: String?
+
+    init(date: Date, projects: [ZeaburProject], isAuthenticated: Bool = false, errorMessage: String? = nil) {
+        self.date = date
+        self.projects = projects
+        self.isAuthenticated = isAuthenticated
+        self.errorMessage = errorMessage
+    }
 }

--- a/src/ZealWidget/ZealWidgetEntryView.swift
+++ b/src/ZealWidget/ZealWidgetEntryView.swift
@@ -19,7 +19,7 @@ struct ZealWidgetEntryView : View {
 
 struct ZealWidgetSmallView: View {
     var entry: Provider.Entry
-    
+
     var body: some View {
         VStack(alignment: .leading) {
             HStack {
@@ -31,11 +31,19 @@ struct ZealWidgetSmallView: View {
                     .fontWeight(.bold)
                     .foregroundColor(.white)
             }
-            
+
             Spacer()
-            
-            if entry.projects.isEmpty {
-                 Text("No Projects")
+
+            if !entry.isAuthenticated {
+                Text("Not logged in")
+                    .font(.caption2)
+                    .foregroundColor(.yellow)
+            } else if let error = entry.errorMessage {
+                Text(error)
+                    .font(.caption2)
+                    .foregroundColor(.red)
+            } else if entry.projects.isEmpty {
+                Text("No Projects")
                     .font(.caption2)
                     .foregroundColor(.gray)
             } else {
@@ -57,7 +65,7 @@ struct ZealWidgetSmallView: View {
 
 struct ZealWidgetMediumView: View {
     var entry: Provider.Entry
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
@@ -68,17 +76,19 @@ struct ZealWidgetMediumView: View {
                     .foregroundColor(.white)
                 Spacer()
             }
-            
-            if entry.projects.isEmpty {
-                if ZeaburService.shared.isAuthenticated {
-                    Text("No projects found.")
-                        .font(.caption)
-                        .foregroundColor(.gray)
-                } else {
-                    Text("Please login in Zeal app.")
-                        .font(.caption)
-                        .foregroundColor(.yellow)
-                }
+
+            if !entry.isAuthenticated {
+                Text("Please login in Zeal app.")
+                    .font(.caption)
+                    .foregroundColor(.yellow)
+            } else if let error = entry.errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            } else if entry.projects.isEmpty {
+                Text("No projects found.")
+                    .font(.caption)
+                    .foregroundColor(.gray)
             } else {
                 VStack(spacing: 8) {
                     ForEach(entry.projects.prefix(3), id: \.id) { project in


### PR DESCRIPTION
- KeychainService now uses dynamic AppIdentifierPrefix from Info.plist instead of hardcoded Team ID, allowing Widget to work with any developer
- Added AppIdentifierPrefix to both main app and Widget Info.plist
- SimpleEntry now includes isAuthenticated and errorMessage for proper state propagation to Widget views
- Widget views now use entry state instead of direct service calls
- Added error state display in both small and medium Widget views

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Widget now displays authentication status with visual indicators—showing login prompts when not authenticated and error messages when operations fail, improving user awareness of app state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->